### PR TITLE
Dockerfile: customize for Haven

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -104,14 +104,14 @@ RUN apt-get update && \
 COPY --from=builder /src/build/release/bin/* /usr/local/bin/
 
 # Contains the blockchain
-VOLUME /root/.bitmonero
+VOLUME /root/.haven
 
 # Generate your wallet via accessing the container and run:
 # cd /wallet
 # haven-wallet-cli
 VOLUME /wallet
 
-EXPOSE 18080
-EXPOSE 18081
+EXPOSE 17749
+EXPOSE 17750
 
-ENTRYPOINT ["havend", "--p2p-bind-ip=0.0.0.0", "--p2p-bind-port=18080", "--rpc-bind-ip=0.0.0.0", "--rpc-bind-port=18081", "--non-interactive", "--confirm-external-bind"] 
+ENTRYPOINT ["havend", "--p2p-bind-ip=0.0.0.0", "--p2p-bind-port=17749", "--rpc-bind-ip=0.0.0.0", "--rpc-bind-port=17750", "--non-interactive", "--confirm-external-bind"] 


### PR DESCRIPTION
For blockchain storage use /root/.haven instead of /root/.bitmonero. Also
change the daemon to run on the default ports configured in the
cryptonote config.

Signed-off-by: Tyler Baker <tyler@opensourcefoundries.com>